### PR TITLE
Add webhook trigger node

### DIFF
--- a/src/app/api/inputwebhook/[customname]/route.ts
+++ b/src/app/api/inputwebhook/[customname]/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest, { params }: { params: { customname: string } }) {
+  let payload = null;
+  try {
+    payload = await req.json();
+  } catch {
+    // ignore
+  }
+
+  console.log('Webhook', params.customname, payload);
+
+  // Здесь можно добавить логику запуска схемы
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/MyFlowDiagram.tsx
+++ b/src/components/MyFlowDiagram.tsx
@@ -31,6 +31,7 @@ import AlertNode from './Nodes/AlertNode';
 import InputTextNode from './Nodes/InputTextNode';
 import DisplayNode from './Nodes/DisplayNode';
 import JsonProcessorNode from './Nodes/JsonProcessorNode';
+import WebhookTriggerNode from './Nodes/WebhookTriggerNode';
 
 const initialNodes: Node[] = [
   // Можно начать с пустого холста или с одного StartNode
@@ -73,6 +74,7 @@ const FlowComponent: React.FC<FlowComponentProps> = ({
     inputTextNode: InputTextNode,
     displayNode: DisplayNode,
     jsonProcessorNode: JsonProcessorNode,
+    webhookTriggerNode: WebhookTriggerNode,
   }), []);
 
   const onConnect: OnConnect = useCallback(
@@ -136,6 +138,19 @@ const FlowComponent: React.FC<FlowComponentProps> = ({
         // StartNode просто инициирует поток, может передать начальное значение если нужно
         console.log('StartNode выполнен.');
         outputData = { message: "Поток запущен!" }; // Пример начальных данных
+        break;
+      case 'webhookTriggerNode':
+        console.log(`WebhookTriggerNode (${node.data.label || 'Webhook Trigger'}) получил:`, currentData);
+
+        setNodes((currentNodes) =>
+          currentNodes.map((n_map) =>
+            n_map.id === nodeId
+              ? { ...n_map, data: { ...n_map.data, incomingData: currentData } }
+              : n_map
+          )
+        );
+
+        outputData = currentData;
         break;
       case 'inputTextNode':
         // InputTextNode получает входящие данные и объединяет их со своим значением
@@ -354,6 +369,15 @@ const FlowComponent: React.FC<FlowComponentProps> = ({
                 incomingData: null,
                 processedValue: null,
                 error: null,
+              },
+            };
+          }
+          if (node.type === 'webhookTriggerNode') {
+            return {
+              ...node,
+              data: {
+                ...node.data,
+                incomingData: null,
               },
             };
           }

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -56,6 +56,14 @@ const NodePalette = () => {
           <p className="font-medium text-slate-100">JSON Processor Node</p>
           <p className="text-xs text-slate-400">Обрабатывает JSON по ключу/индексу</p>
         </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'webhookTriggerNode', 'Webhook Trigger')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Webhook Trigger Node</p>
+          <p className="text-xs text-slate-400">Запускает логику через webhook</p>
+        </div>
       </div>
     </aside>
   );

--- a/src/components/Nodes/WebhookTriggerNode.tsx
+++ b/src/components/Nodes/WebhookTriggerNode.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { Handle, Position, NodeProps, useReactFlow } from '@xyflow/react';
+
+interface WebhookTriggerData {
+  label?: string;
+  customName?: string;
+  incomingData?: any;
+}
+
+const WebhookTriggerNode = ({ id, data }: NodeProps<WebhookTriggerData>) => {
+  const { setNodes } = useReactFlow();
+  const [customNameValue, setCustomNameValue] = useState(data.customName || '');
+
+  const onCustomNameChange = useCallback(
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = evt.target.value;
+      setCustomNameValue(newValue);
+      setNodes((currentNodes) =>
+        currentNodes.map((node) =>
+          node.id === id
+            ? { ...node, data: { ...node.data, customName: newValue } }
+            : node
+        )
+      );
+    },
+    [id, setNodes]
+  );
+
+  const renderIncomingData = () => {
+    if (data.incomingData !== undefined) {
+      return (
+        <div className="text-xs text-teal-200 mb-2 p-1 bg-teal-800 rounded break-words max-h-32 overflow-y-auto">
+          {typeof data.incomingData === 'object'
+            ? JSON.stringify(data.incomingData, null, 2)
+            : String(data.incomingData)}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const pathPreview = customNameValue || '<name>';
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-teal-600 border-2 border-teal-700 text-white w-60">
+      <div className="text-sm font-bold mb-2">{data.label || 'Webhook Trigger'}</div>
+
+      <div className="mb-2">
+        <label className="block text-xs text-teal-200 mb-1">Custom name:</label>
+        <input
+          type="text"
+          value={customNameValue}
+          onChange={onCustomNameChange}
+          className="w-full px-2 py-1 rounded-md bg-teal-700 text-teal-50 placeholder-teal-300 text-xs"
+          placeholder="myhook"
+        />
+      </div>
+
+      <div className="text-xs text-teal-200 mb-2">POST /api/inputwebhook/{pathPreview}</div>
+
+      {renderIncomingData()}
+
+      <Handle type="source" position={Position.Right} id="output" className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default WebhookTriggerNode;


### PR DESCRIPTION
## Summary
- add `WebhookTriggerNode` component for React Flow
- register the new node type and palette entry
- clear WebhookTriggerNode state on run start
- create POST API route `/api/inputwebhook/[customname]`

## Testing
- `npx next lint` *(fails: couldn't find pages or many lint errors)*
- `npm run build` *(fails: unable to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68425cfa18dc8322ad05d05d4c057b6e