### PR TITLE
Add Telegram message node

### DIFF
--- a/src/components/MyFlowDiagram.tsx
+++ b/src/components/MyFlowDiagram.tsx
@@ -32,6 +32,7 @@ import InputTextNode from './Nodes/InputTextNode';
 import DisplayNode from './Nodes/DisplayNode';
 import JsonProcessorNode from './Nodes/JsonProcessorNode';
 import WebhookTriggerNode from './Nodes/WebhookTriggerNode';
+import TelegramNode from './Nodes/TelegramNode';
 
 const initialNodes: Node[] = [
   // Можно начать с пустого холста или с одного StartNode
@@ -75,6 +76,7 @@ const FlowComponent: React.FC<FlowComponentProps> = ({
     displayNode: DisplayNode,
     jsonProcessorNode: JsonProcessorNode,
     webhookTriggerNode: WebhookTriggerNode,
+    telegramNode: TelegramNode,
   }), []);
 
   const onConnect: OnConnect = useCallback(
@@ -305,6 +307,34 @@ const FlowComponent: React.FC<FlowComponentProps> = ({
         // JsonProcessorNode выдает обработанное значение
         outputData = processedValue;
         console.log(`JsonProcessorNode (${node.data.label || 'JSON Processor'}) выдал:`, outputData);
+        break;
+      case 'telegramNode':
+        console.log(`TelegramNode (${node.data.label || 'Telegram'}) получил:`, currentData);
+
+        setNodes((currentNodes) =>
+          currentNodes.map((n_map) =>
+            n_map.id === nodeId
+              ? { ...n_map, data: { ...n_map.data, incomingData: currentData } }
+              : n_map
+          )
+        );
+
+        try {
+          const text =
+            typeof currentData === 'string'
+              ? currentData
+              : JSON.stringify(currentData);
+          const url =
+            'https://api.telegram.org/bot1434601883:AAFDS330oYhld1GttIMLh49gBDnetCezU2A/sendMessage?chat_id=854186602&text=' +
+            encodeURIComponent(text);
+          fetch(url, { method: 'POST' }).catch((err) =>
+            console.error('TelegramNode fetch error:', err)
+          );
+        } catch (err) {
+          console.error('TelegramNode error:', err);
+        }
+
+        outputData = currentData;
         break;
       default:
         console.warn(`Неизвестный тип узла для выполнения: ${node.type}`);

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -64,6 +64,14 @@ const NodePalette = () => {
           <p className="font-medium text-slate-100">Webhook Trigger Node</p>
           <p className="text-xs text-slate-400">Запускает логику через webhook</p>
         </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'telegramNode', 'Telegram')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Telegram Node</p>
+          <p className="text-xs text-slate-400">Отправляет текст в Telegram</p>
+        </div>
       </div>
     </aside>
   );

--- a/src/components/Nodes/TelegramNode.tsx
+++ b/src/components/Nodes/TelegramNode.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const TelegramNode = ({ data }: NodeProps<{ label?: string; incomingData?: any }>) => {
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-blue-700 border-2 border-blue-800 text-white w-48">
+      <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
+      <div className="flex flex-col">
+        <div className="text-sm font-bold mb-1">{data.label || 'Telegram'}</div>
+        <div className="text-xs p-2 bg-blue-800/70 rounded-sm min-h-[30px]">
+          {data.incomingData !== undefined ? (
+            <pre className="whitespace-pre-wrap break-all">{JSON.stringify(data.incomingData, null, 2)}</pre>
+          ) : (
+            <span className="italic opacity-70">Ожидание данных...</span>
+          )}
+        </div>
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default TelegramNode;


### PR DESCRIPTION
## Summary
- add Telegram node component to display and send incoming data
- enable telegramNode type in React Flow diagram and handle its logic
- expose Telegram node in the palette

## Testing
- `npm run lint` *(fails: Expected an assignment or function call and instead saw an expression)*

------
https://chatgpt.com/codex/tasks/task_e_6842a5a5588483228c8fb80ecff0684b