### PR TITLE
Implement flow saving and loading with webhook

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,9 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    ignores: ["src/generated/**"]
+  }
 ];
 
 export default eslintConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,16 @@ model Node {
   updatedAt DateTime @updatedAt
 }
 
+model Flow {
+  id          String   @id @default(cuid())
+  name        String
+  nodes       Json
+  edges       Json
+  webhookName String?  @unique
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
 
 generator client {
   provider = "prisma-client-js"

--- a/src/app/api/inputwebhook/[customname]/route.ts
+++ b/src/app/api/inputwebhook/[customname]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
 
 export async function POST(req: NextRequest, { params }: { params: { customname: string } }) {
   let payload = null;
@@ -10,7 +11,13 @@ export async function POST(req: NextRequest, { params }: { params: { customname:
 
   console.log('Webhook', params.customname, payload);
 
-  // Здесь можно добавить логику запуска схемы
+  const flow = await prisma.flow.findFirst({ where: { webhookName: params.customname } });
 
-  return NextResponse.json({ ok: true });
+  if (!flow) {
+    return NextResponse.json({ error: 'Flow not found' }, { status: 404 });
+  }
+
+  // Здесь можно добавить логику запуска схемы с использованием flow.nodes и flow.edges
+
+  return NextResponse.json({ ok: true, flowId: flow.id });
 }

--- a/src/app/api/logic/[id]/route.ts
+++ b/src/app/api/logic/[id]/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const flow = await prisma.flow.findUnique({ where: { id: params.id } });
+  if (!flow) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json(flow);
+}

--- a/src/app/api/logic/list/route.ts
+++ b/src/app/api/logic/list/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET() {
+  const flows = await prisma.flow.findMany({
+    select: { id: true, name: true, createdAt: true },
+    orderBy: { createdAt: 'desc' },
+  });
+  return NextResponse.json(flows);
+}

--- a/src/app/api/logic/save/route.ts
+++ b/src/app/api/logic/save/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { name, nodes, edges } = await req.json();
+    if (!name) {
+      return NextResponse.json({ error: 'Missing name' }, { status: 400 });
+    }
+
+    const webhookNode = Array.isArray(nodes)
+      ? nodes.find((n: any) => n.type === 'webhookTriggerNode' && n.data?.customName)
+      : undefined;
+
+    const flow = await prisma.flow.create({
+      data: {
+        name,
+        nodes,
+        edges,
+        webhookName: webhookNode?.data?.customName,
+      },
+    });
+
+    return NextResponse.json({ id: flow.id });
+  } catch (error) {
+    console.error('Save flow error:', error);
+    return NextResponse.json({ error: 'Failed to save' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- define a new `Flow` model for storing flow JSON
- add API routes to save, list and load flows
- bind webhook triggers to saved flows
- expose diagram state through `MyFlowDiagram` ref
- enable saving/loading on the homepage
- ignore generated folder in ESLint

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_6842a72566c483228617f2487fb30269