### PR TITLE
Add trigger node components

### DIFF
--- a/src/components/MyFlowDiagram.tsx
+++ b/src/components/MyFlowDiagram.tsx
@@ -33,6 +33,12 @@ import DisplayNode from './Nodes/DisplayNode';
 import JsonProcessorNode from './Nodes/JsonProcessorNode';
 import WebhookTriggerNode from './Nodes/WebhookTriggerNode';
 import TelegramNode from './Nodes/TelegramNode';
+import ScheduleNode from './Nodes/ScheduleNode';
+import FileWatcherNode from './Nodes/FileWatcherNode';
+import DatabaseTriggerNode from './Nodes/DatabaseTriggerNode';
+import TelegramListenerNode from './Nodes/TelegramListenerNode';
+import MqttListenerNode from './Nodes/MqttListenerNode';
+import EmailTriggerNode from './Nodes/EmailTriggerNode';
 
 const initialNodes: Node[] = [
   // Можно начать с пустого холста или с одного StartNode
@@ -83,6 +89,12 @@ const FlowComponent = forwardRef<FlowComponentRef, FlowComponentProps>(function 
     jsonProcessorNode: JsonProcessorNode,
     webhookTriggerNode: WebhookTriggerNode,
     telegramNode: TelegramNode,
+    scheduleNode: ScheduleNode,
+    fileWatcherNode: FileWatcherNode,
+    databaseTriggerNode: DatabaseTriggerNode,
+    telegramListenerNode: TelegramListenerNode,
+    mqttListenerNode: MqttListenerNode,
+    emailTriggerNode: EmailTriggerNode,
   }), []);
 
   useImperativeHandle(ref, () => ({
@@ -350,6 +362,20 @@ const FlowComponent = forwardRef<FlowComponentRef, FlowComponentProps>(function 
 
         outputData = currentData;
         break;
+      case 'scheduleNode':
+      case 'fileWatcherNode':
+      case 'databaseTriggerNode':
+      case 'telegramListenerNode':
+      case 'mqttListenerNode':
+      case 'emailTriggerNode':
+        console.log(`${node.type} (${node.data.label || node.type}) получил:`, currentData);
+        setNodes((currentNodes) =>
+          currentNodes.map((n_map) =>
+            n_map.id === nodeId ? { ...n_map, data: { ...n_map.data, incomingData: currentData } } : n_map
+          )
+        );
+        outputData = currentData;
+        break;
       default:
         console.warn(`Неизвестный тип узла для выполнения: ${node.type}`);
         break;
@@ -417,6 +443,22 @@ const FlowComponent = forwardRef<FlowComponentRef, FlowComponentProps>(function 
             };
           }
           if (node.type === 'webhookTriggerNode') {
+            return {
+              ...node,
+              data: {
+                ...node.data,
+                incomingData: null,
+              },
+            };
+          }
+          if (
+            node.type === 'scheduleNode' ||
+            node.type === 'fileWatcherNode' ||
+            node.type === 'databaseTriggerNode' ||
+            node.type === 'telegramListenerNode' ||
+            node.type === 'mqttListenerNode' ||
+            node.type === 'emailTriggerNode'
+          ) {
             return {
               ...node,
               data: {

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -72,6 +72,54 @@ const NodePalette = () => {
           <p className="font-medium text-slate-100">Telegram Node</p>
           <p className="text-xs text-slate-400">Отправляет текст в Telegram</p>
         </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'scheduleNode', 'Schedule')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Schedule Node</p>
+          <p className="text-xs text-slate-400">Запуск по расписанию</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'fileWatcherNode', 'File Watcher')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">File Watcher Node</p>
+          <p className="text-xs text-slate-400">Изменение файла в папке</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'databaseTriggerNode', 'DB Trigger')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Database Trigger Node</p>
+          <p className="text-xs text-slate-400">Новые данные в БД</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'telegramListenerNode', 'Telegram Listener')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Telegram Listener Node</p>
+          <p className="text-xs text-slate-400">Новое сообщение Telegram</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'mqttListenerNode', 'MQTT Listener')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">MQTT Listener Node</p>
+          <p className="text-xs text-slate-400">Сообщение в MQTT канале</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'emailTriggerNode', 'Email Trigger')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Email Trigger Node</p>
+          <p className="text-xs text-slate-400">Получение письма</p>
+        </div>
       </div>
     </aside>
   );

--- a/src/components/Nodes/DatabaseTriggerNode.tsx
+++ b/src/components/Nodes/DatabaseTriggerNode.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { Handle, Position, NodeProps, useReactFlow } from '@xyflow/react';
+
+interface DatabaseTriggerData {
+  label?: string;
+  table?: string;
+}
+
+const DatabaseTriggerNode = ({ id, data }: NodeProps<DatabaseTriggerData>) => {
+  const { setNodes } = useReactFlow();
+  const [tableValue, setTableValue] = useState(data.table || '');
+
+  const onTableChange = useCallback(
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = evt.target.value;
+      setTableValue(newValue);
+      setNodes((currentNodes) =>
+        currentNodes.map((n) =>
+          n.id === id ? { ...n, data: { ...n.data, table: newValue } } : n
+        )
+      );
+    },
+    [id, setNodes]
+  );
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-orange-700 border-2 border-orange-800 text-white w-56">
+      <div className="text-sm font-bold mb-2">{data.label || 'DB Trigger'}</div>
+      <div className="mb-2">
+        <label className="block text-xs text-orange-200 mb-1">Таблица:</label>
+        <input
+          type="text"
+          value={tableValue}
+          onChange={onTableChange}
+          className="w-full px-2 py-1 text-xs bg-orange-800 border border-orange-600 rounded text-white placeholder-orange-300"
+          placeholder="users"
+        />
+      </div>
+      <Handle type="source" position={Position.Right} id="output" className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default DatabaseTriggerNode;

--- a/src/components/Nodes/EmailTriggerNode.tsx
+++ b/src/components/Nodes/EmailTriggerNode.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { Handle, Position, NodeProps, useReactFlow } from '@xyflow/react';
+
+interface EmailTriggerData {
+  label?: string;
+  address?: string;
+}
+
+const EmailTriggerNode = ({ id, data }: NodeProps<EmailTriggerData>) => {
+  const { setNodes } = useReactFlow();
+  const [addressValue, setAddressValue] = useState(data.address || '');
+
+  const onAddressChange = useCallback(
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = evt.target.value;
+      setAddressValue(newValue);
+      setNodes((currentNodes) =>
+        currentNodes.map((n) =>
+          n.id === id ? { ...n, data: { ...n.data, address: newValue } } : n
+        )
+      );
+    },
+    [id, setNodes]
+  );
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-pink-700 border-2 border-pink-800 text-white w-56">
+      <div className="text-sm font-bold mb-2">{data.label || 'Email Trigger'}</div>
+      <div className="mb-2">
+        <label className="block text-xs text-pink-200 mb-1">Адрес:</label>
+        <input
+          type="text"
+          value={addressValue}
+          onChange={onAddressChange}
+          className="w-full px-2 py-1 text-xs bg-pink-800 border border-pink-600 rounded text-white placeholder-pink-300"
+          placeholder="user@example.com"
+        />
+      </div>
+      <Handle type="source" position={Position.Right} id="output" className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default EmailTriggerNode;

--- a/src/components/Nodes/FileWatcherNode.tsx
+++ b/src/components/Nodes/FileWatcherNode.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { Handle, Position, NodeProps, useReactFlow } from '@xyflow/react';
+
+interface FileWatcherData {
+  label?: string;
+  folder?: string;
+}
+
+const FileWatcherNode = ({ id, data }: NodeProps<FileWatcherData>) => {
+  const { setNodes } = useReactFlow();
+  const [folderValue, setFolderValue] = useState(data.folder || '');
+
+  const onFolderChange = useCallback(
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = evt.target.value;
+      setFolderValue(newValue);
+      setNodes((currentNodes) =>
+        currentNodes.map((n) =>
+          n.id === id ? { ...n, data: { ...n.data, folder: newValue } } : n
+        )
+      );
+    },
+    [id, setNodes]
+  );
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-purple-700 border-2 border-purple-800 text-white w-56">
+      <div className="text-sm font-bold mb-2">{data.label || 'File Watcher'}</div>
+      <div className="mb-2">
+        <label className="block text-xs text-purple-200 mb-1">Папка:</label>
+        <input
+          type="text"
+          value={folderValue}
+          onChange={onFolderChange}
+          className="w-full px-2 py-1 text-xs bg-purple-800 border border-purple-600 rounded text-white placeholder-purple-300"
+          placeholder="/path/to/folder"
+        />
+      </div>
+      <Handle type="source" position={Position.Right} id="output" className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default FileWatcherNode;

--- a/src/components/Nodes/MqttListenerNode.tsx
+++ b/src/components/Nodes/MqttListenerNode.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { Handle, Position, NodeProps, useReactFlow } from '@xyflow/react';
+
+interface MqttListenerData {
+  label?: string;
+  topic?: string;
+}
+
+const MqttListenerNode = ({ id, data }: NodeProps<MqttListenerData>) => {
+  const { setNodes } = useReactFlow();
+  const [topicValue, setTopicValue] = useState(data.topic || '');
+
+  const onTopicChange = useCallback(
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = evt.target.value;
+      setTopicValue(newValue);
+      setNodes((currentNodes) =>
+        currentNodes.map((n) =>
+          n.id === id ? { ...n, data: { ...n.data, topic: newValue } } : n
+        )
+      );
+    },
+    [id, setNodes]
+  );
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-teal-700 border-2 border-teal-800 text-white w-56">
+      <div className="text-sm font-bold mb-2">{data.label || 'MQTT Listener'}</div>
+      <div className="mb-2">
+        <label className="block text-xs text-teal-200 mb-1">Topic:</label>
+        <input
+          type="text"
+          value={topicValue}
+          onChange={onTopicChange}
+          className="w-full px-2 py-1 text-xs bg-teal-800 border border-teal-600 rounded text-white placeholder-teal-300"
+          placeholder="sensors/temperature"
+        />
+      </div>
+      <Handle type="source" position={Position.Right} id="output" className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default MqttListenerNode;

--- a/src/components/Nodes/ScheduleNode.tsx
+++ b/src/components/Nodes/ScheduleNode.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { Handle, Position, NodeProps, useReactFlow } from '@xyflow/react';
+
+interface ScheduleNodeData {
+  label?: string;
+  cron?: string;
+}
+
+const ScheduleNode = ({ id, data }: NodeProps<ScheduleNodeData>) => {
+  const { setNodes } = useReactFlow();
+  const [cronValue, setCronValue] = useState(data.cron || '');
+
+  const onCronChange = useCallback(
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = evt.target.value;
+      setCronValue(newValue);
+      setNodes((currentNodes) =>
+        currentNodes.map((n) =>
+          n.id === id ? { ...n, data: { ...n.data, cron: newValue } } : n
+        )
+      );
+    },
+    [id, setNodes]
+  );
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-emerald-700 border-2 border-emerald-800 text-white w-56">
+      <div className="text-sm font-bold mb-2">{data.label || 'Schedule'}</div>
+      <div className="mb-2">
+        <label className="block text-xs text-emerald-200 mb-1">Cron выражение:</label>
+        <input
+          type="text"
+          value={cronValue}
+          onChange={onCronChange}
+          className="w-full px-2 py-1 text-xs bg-emerald-800 border border-emerald-600 rounded text-white placeholder-emerald-300"
+          placeholder="0 * * * *"
+        />
+      </div>
+      <Handle type="source" position={Position.Right} id="output" className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default ScheduleNode;

--- a/src/components/Nodes/TelegramListenerNode.tsx
+++ b/src/components/Nodes/TelegramListenerNode.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const TelegramListenerNode = ({ data }: NodeProps<{ label?: string }>) => {
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-blue-600 border-2 border-blue-800 text-white w-48">
+      <div className="text-sm font-bold mb-2">{data.label || 'Telegram Listener'}</div>
+      <div className="text-xs italic opacity-80 mb-2">Ожидание сообщения...</div>
+      <Handle type="source" position={Position.Right} id="output" className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default TelegramListenerNode;


### PR DESCRIPTION
## Summary
- implement trigger nodes for scheduling, file watching, DB changes, telegram, MQTT and email
- register new nodes in MyFlowDiagram and NodePalette
- handle clearing data and processing for new node types

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6842cdb4c6dc8322b0d10555a904d1dd