### PR TITLE
Add AI/ML nodes

### DIFF
--- a/src/components/MyFlowDiagram.tsx
+++ b/src/components/MyFlowDiagram.tsx
@@ -39,6 +39,16 @@ import DatabaseTriggerNode from './Nodes/DatabaseTriggerNode';
 import TelegramListenerNode from './Nodes/TelegramListenerNode';
 import MqttListenerNode from './Nodes/MqttListenerNode';
 import EmailTriggerNode from './Nodes/EmailTriggerNode';
+import LLMNode from './Nodes/LLMNode';
+import EmbeddingNode from './Nodes/EmbeddingNode';
+import VectorSearchNode from './Nodes/VectorSearchNode';
+import LangChainAgentNode from './Nodes/LangChainAgentNode';
+import RAGNode from './Nodes/RAGNode';
+import SentimentAnalysisNode from './Nodes/SentimentAnalysisNode';
+import TextClassificationNode from './Nodes/TextClassificationNode';
+import SummarizationNode from './Nodes/SummarizationNode';
+import TextToSQLNode from './Nodes/TextToSQLNode';
+import PromptTemplateNode from './Nodes/PromptTemplateNode';
 
 const initialNodes: Node[] = [
   // Можно начать с пустого холста или с одного StartNode
@@ -95,6 +105,16 @@ const FlowComponent = forwardRef<FlowComponentRef, FlowComponentProps>(function 
     telegramListenerNode: TelegramListenerNode,
     mqttListenerNode: MqttListenerNode,
     emailTriggerNode: EmailTriggerNode,
+    llmNode: LLMNode,
+    embeddingNode: EmbeddingNode,
+    vectorSearchNode: VectorSearchNode,
+    langChainAgentNode: LangChainAgentNode,
+    ragNode: RAGNode,
+    sentimentAnalysisNode: SentimentAnalysisNode,
+    textClassificationNode: TextClassificationNode,
+    summarizationNode: SummarizationNode,
+    textToSQLNode: TextToSQLNode,
+    promptTemplateNode: PromptTemplateNode,
   }), []);
 
   useImperativeHandle(ref, () => ({

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -120,6 +120,87 @@ const NodePalette = () => {
           <p className="font-medium text-slate-100">Email Trigger Node</p>
           <p className="text-xs text-slate-400">Получение письма</p>
         </div>
+        {/* AI / NLP / ML nodes */}
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'llmNode', 'LLM')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">LLM Node</p>
+          <p className="text-xs text-slate-400">Запрос к LLM</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'embeddingNode', 'Embedding')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Embedding Node</p>
+          <p className="text-xs text-slate-400">Текст в вектор</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'vectorSearchNode', 'Vector Search')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Vector Search Node</p>
+          <p className="text-xs text-slate-400">Поиск векторов</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'langChainAgentNode', 'LangChain Agent')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">LangChain Agent Node</p>
+          <p className="text-xs text-slate-400">Запуск агента</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'ragNode', 'RAG')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">RAG Node</p>
+          <p className="text-xs text-slate-400">Документы + LLM</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'sentimentAnalysisNode', 'Sentiment')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Sentiment Analysis Node</p>
+          <p className="text-xs text-slate-400">Определяет настроение</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'textClassificationNode', 'Text Classify')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Text Classification Node</p>
+          <p className="text-xs text-slate-400">Классифицирует текст</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'summarizationNode', 'Summarization')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Summarization Node</p>
+          <p className="text-xs text-slate-400">Сжимает текст</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'textToSQLNode', 'Text to SQL')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Text-to-SQL Node</p>
+          <p className="text-xs text-slate-400">Генерация SQL</p>
+        </div>
+        <div
+          className="p-3 border border-slate-700 bg-slate-700/50 rounded-md shadow hover:shadow-lg hover:border-sky-500 cursor-grab transition-all duration-150 ease-in-out"
+          onDragStart={(event) => onDragStart(event, 'promptTemplateNode', 'Prompt Template')}
+          draggable
+        >
+          <p className="font-medium text-slate-100">Prompt Template Node</p>
+          <p className="text-xs text-slate-400">Шаблон с переменными</p>
+        </div>
       </div>
     </aside>
   );

--- a/src/components/Nodes/EmbeddingNode.tsx
+++ b/src/components/Nodes/EmbeddingNode.tsx
@@ -1,0 +1,37 @@
+// src/components/Nodes/EmbeddingNode.tsx
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const EmbeddingNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>) => {
+  const renderValue = (value: unknown) => {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        return '[object]';
+      }
+    }
+    return String(value);
+  };
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-teal-600 border-2 border-teal-700 text-white w-60">
+      <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
+      <div className="text-sm font-bold mb-2">{data.label || 'Embedding'}</div>
+      <div className="text-xs p-2 bg-teal-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto">
+        {data.incomingData !== undefined ? (
+          <pre className="whitespace-pre-wrap break-all">{renderValue(data.incomingData)}</pre>
+        ) : (
+          <span className="italic opacity-70">Ожидание данных...</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default EmbeddingNode;

--- a/src/components/Nodes/LLMNode.tsx
+++ b/src/components/Nodes/LLMNode.tsx
@@ -1,0 +1,37 @@
+// src/components/Nodes/LLMNode.tsx
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const LLMNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>) => {
+  const renderValue = (value: unknown) => {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        return '[object]';
+      }
+    }
+    return String(value);
+  };
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-indigo-600 border-2 border-indigo-700 text-white w-60">
+      <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
+      <div className="text-sm font-bold mb-2">{data.label || 'LLM'}</div>
+      <div className="text-xs p-2 bg-indigo-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto">
+        {data.incomingData !== undefined ? (
+          <pre className="whitespace-pre-wrap break-all">{renderValue(data.incomingData)}</pre>
+        ) : (
+          <span className="italic opacity-70">Ожидание данных...</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default LLMNode;

--- a/src/components/Nodes/LangChainAgentNode.tsx
+++ b/src/components/Nodes/LangChainAgentNode.tsx
@@ -1,0 +1,37 @@
+// src/components/Nodes/LangChainAgentNode.tsx
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const LangChainAgentNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>) => {
+  const renderValue = (value: unknown) => {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        return '[object]';
+      }
+    }
+    return String(value);
+  };
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-lime-600 border-2 border-lime-700 text-white w-60">
+      <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
+      <div className="text-sm font-bold mb-2">{data.label || 'LangChain Agent'}</div>
+      <div className="text-xs p-2 bg-lime-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto">
+        {data.incomingData !== undefined ? (
+          <pre className="whitespace-pre-wrap break-all">{renderValue(data.incomingData)}</pre>
+        ) : (
+          <span className="italic opacity-70">Ожидание данных...</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default LangChainAgentNode;

--- a/src/components/Nodes/PromptTemplateNode.tsx
+++ b/src/components/Nodes/PromptTemplateNode.tsx
@@ -1,0 +1,37 @@
+// src/components/Nodes/PromptTemplateNode.tsx
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const PromptTemplateNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>) => {
+  const renderValue = (value: unknown) => {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        return '[object]';
+      }
+    }
+    return String(value);
+  };
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-slate-600 border-2 border-slate-700 text-white w-60">
+      <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
+      <div className="text-sm font-bold mb-2">{data.label || 'Prompt Template'}</div>
+      <div className="text-xs p-2 bg-slate-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto">
+        {data.incomingData !== undefined ? (
+          <pre className="whitespace-pre-wrap break-all">{renderValue(data.incomingData)}</pre>
+        ) : (
+          <span className="italic opacity-70">Ожидание данных...</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default PromptTemplateNode;

--- a/src/components/Nodes/RAGNode.tsx
+++ b/src/components/Nodes/RAGNode.tsx
@@ -1,0 +1,37 @@
+// src/components/Nodes/RAGNode.tsx
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const RAGNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>) => {
+  const renderValue = (value: unknown) => {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        return '[object]';
+      }
+    }
+    return String(value);
+  };
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-emerald-600 border-2 border-emerald-700 text-white w-60">
+      <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
+      <div className="text-sm font-bold mb-2">{data.label || 'RAG'}</div>
+      <div className="text-xs p-2 bg-emerald-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto">
+        {data.incomingData !== undefined ? (
+          <pre className="whitespace-pre-wrap break-all">{renderValue(data.incomingData)}</pre>
+        ) : (
+          <span className="italic opacity-70">Ожидание данных...</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default RAGNode;

--- a/src/components/Nodes/SentimentAnalysisNode.tsx
+++ b/src/components/Nodes/SentimentAnalysisNode.tsx
@@ -1,0 +1,37 @@
+// src/components/Nodes/SentimentAnalysisNode.tsx
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const SentimentAnalysisNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>) => {
+  const renderValue = (value: unknown) => {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        return '[object]';
+      }
+    }
+    return String(value);
+  };
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-pink-600 border-2 border-pink-700 text-white w-60">
+      <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
+      <div className="text-sm font-bold mb-2">{data.label || 'Sentiment'}</div>
+      <div className="text-xs p-2 bg-pink-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto">
+        {data.incomingData !== undefined ? (
+          <pre className="whitespace-pre-wrap break-all">{renderValue(data.incomingData)}</pre>
+        ) : (
+          <span className="italic opacity-70">Ожидание данных...</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default SentimentAnalysisNode;

--- a/src/components/Nodes/SummarizationNode.tsx
+++ b/src/components/Nodes/SummarizationNode.tsx
@@ -1,0 +1,37 @@
+// src/components/Nodes/SummarizationNode.tsx
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const SummarizationNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>) => {
+  const renderValue = (value: unknown) => {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        return '[object]';
+      }
+    }
+    return String(value);
+  };
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-orange-500 border-2 border-orange-600 text-white w-60">
+      <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
+      <div className="text-sm font-bold mb-2">{data.label || 'Summarization'}</div>
+      <div className="text-xs p-2 bg-orange-600/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto">
+        {data.incomingData !== undefined ? (
+          <pre className="whitespace-pre-wrap break-all">{renderValue(data.incomingData)}</pre>
+        ) : (
+          <span className="italic opacity-70">Ожидание данных...</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default SummarizationNode;

--- a/src/components/Nodes/TextClassificationNode.tsx
+++ b/src/components/Nodes/TextClassificationNode.tsx
@@ -1,0 +1,37 @@
+// src/components/Nodes/TextClassificationNode.tsx
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const TextClassificationNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>) => {
+  const renderValue = (value: unknown) => {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        return '[object]';
+      }
+    }
+    return String(value);
+  };
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-yellow-600 border-2 border-yellow-700 text-white w-60">
+      <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
+      <div className="text-sm font-bold mb-2">{data.label || 'Text Classify'}</div>
+      <div className="text-xs p-2 bg-yellow-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto">
+        {data.incomingData !== undefined ? (
+          <pre className="whitespace-pre-wrap break-all">{renderValue(data.incomingData)}</pre>
+        ) : (
+          <span className="italic opacity-70">Ожидание данных...</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default TextClassificationNode;

--- a/src/components/Nodes/TextToSQLNode.tsx
+++ b/src/components/Nodes/TextToSQLNode.tsx
@@ -1,0 +1,37 @@
+// src/components/Nodes/TextToSQLNode.tsx
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const TextToSQLNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>) => {
+  const renderValue = (value: unknown) => {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        return '[object]';
+      }
+    }
+    return String(value);
+  };
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-fuchsia-600 border-2 border-fuchsia-700 text-white w-60">
+      <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
+      <div className="text-sm font-bold mb-2">{data.label || 'Text to SQL'}</div>
+      <div className="text-xs p-2 bg-fuchsia-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto">
+        {data.incomingData !== undefined ? (
+          <pre className="whitespace-pre-wrap break-all">{renderValue(data.incomingData)}</pre>
+        ) : (
+          <span className="italic opacity-70">Ожидание данных...</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default TextToSQLNode;

--- a/src/components/Nodes/VectorSearchNode.tsx
+++ b/src/components/Nodes/VectorSearchNode.tsx
@@ -1,0 +1,37 @@
+// src/components/Nodes/VectorSearchNode.tsx
+'use client';
+
+import React from 'react';
+import { Handle, Position, NodeProps } from '@xyflow/react';
+
+const VectorSearchNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>) => {
+  const renderValue = (value: unknown) => {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        return '[object]';
+      }
+    }
+    return String(value);
+  };
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-cyan-600 border-2 border-cyan-700 text-white w-60">
+      <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
+      <div className="text-sm font-bold mb-2">{data.label || 'Vector Search'}</div>
+      <div className="text-xs p-2 bg-cyan-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto">
+        {data.incomingData !== undefined ? (
+          <pre className="whitespace-pre-wrap break-all">{renderValue(data.incomingData)}</pre>
+        ) : (
+          <span className="italic opacity-70">Ожидание данных...</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
+    </div>
+  );
+};
+
+export default VectorSearchNode;


### PR DESCRIPTION
## Summary
- create LLM, Embedding, VectorSearch, LangChainAgent, RAG, SentimentAnalysis, TextClassification, Summarization, TextToSQL and PromptTemplate nodes
- register new nodes in diagram and palette

## Testing
- `npm run build` *(fails: Failed to fetch fonts)*
- `npm run lint` *(fails: unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_6842d19bd9888322a4cb3799783e2fe8