### PR TITLE
Add async LLM node and API

### DIFF
--- a/src/app/api/llm/route.ts
+++ b/src/app/api/llm/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { prompt, memory, config = {} } = await req.json();
+    const {
+      model = 'gpt-3.5-turbo',
+      apiKey = process.env.OPENAI_API_KEY,
+      temperature = 0.7,
+      mode = 'chat',
+      output_format = 'text',
+      ...rest
+    } = config;
+
+    if (!apiKey) {
+      return NextResponse.json({ error: 'Missing API key' }, { status: 400 });
+    }
+
+    let body: Record<string, unknown>;
+
+    if (mode === 'chat') {
+      const messages: Array<{ role: string; content: string }> = [];
+      if (Array.isArray(memory)) {
+        for (const m of memory) {
+          if (m && typeof m === 'object' && 'role' in m && 'content' in m) {
+            messages.push({ role: m.role, content: m.content });
+          }
+        }
+      }
+      if (prompt && typeof prompt === 'object' && Array.isArray(prompt.messages)) {
+        messages.push(...prompt.messages);
+      } else if (typeof prompt === 'string') {
+        messages.push({ role: 'user', content: prompt });
+      }
+      body = { model, messages, temperature, ...rest };
+    } else {
+      const p = typeof prompt === 'string' ? prompt : JSON.stringify(prompt);
+      body = { model, prompt: p, temperature, ...rest };
+    }
+
+    const apiUrl = `https://api.openai.com/v1/${mode === 'chat' ? 'chat/completions' : 'completions'}`;
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const json = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json({ error: json.error?.message || 'LLM error', raw_output: json }, { status: response.status });
+    }
+
+    const text = mode === 'chat' ? json.choices?.[0]?.message?.content : json.choices?.[0]?.text;
+
+    if (output_format === 'json') {
+      try {
+        return NextResponse.json({ response: JSON.parse(text), raw_output: json });
+      } catch {
+        return NextResponse.json({ response: text, raw_output: json });
+      }
+    }
+
+    return NextResponse.json({ response: text, raw_output: json });
+  } catch (e) {
+    console.error('LLM API error:', e);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/src/app/api/logic/save/route.ts
+++ b/src/app/api/logic/save/route.ts
@@ -9,7 +9,9 @@ export async function POST(req: NextRequest) {
     }
 
     const webhookNode = Array.isArray(nodes)
-      ? nodes.find((n: any) => n.type === 'webhookTriggerNode' && n.data?.customName)
+      ? nodes.find((n: { type?: string; data?: Record<string, unknown> }) =>
+          n.type === 'webhookTriggerNode' &&
+          typeof (n.data?.customName) === 'string')
       : undefined;
 
     const flow = await prisma.flow.create({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,10 +49,4 @@ export const metadata: Metadata = {
   description: "Визуальный конструктор логических схем с поддержкой узлов обработки данных",
 };
 
-// Добавляем preconnect для Google Fonts
-const fontPreconnectLinks = [
-  { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-  { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossOrigin: 'anonymous' }
-];
-
 

--- a/src/components/Nodes/LLMNode.tsx
+++ b/src/components/Nodes/LLMNode.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { Handle, Position, NodeProps } from '@xyflow/react';
 
-const LLMNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>) => {
+const LLMNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown; response?: unknown; error?: string }>) => {
   const renderValue = (value: unknown) => {
     if (value === null) return 'null';
     if (value === undefined) return 'undefined';
@@ -22,13 +22,21 @@ const LLMNode = ({ data }: NodeProps<{ label?: string; incomingData?: unknown }>
     <div className="px-4 py-3 shadow-md rounded-md bg-indigo-600 border-2 border-indigo-700 text-white w-60">
       <Handle type="target" position={Position.Left} className="!bg-slate-700 !w-3 !h-3" />
       <div className="text-sm font-bold mb-2">{data.label || 'LLM'}</div>
-      <div className="text-xs p-2 bg-indigo-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto">
+      <div className="text-xs p-2 bg-indigo-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto mb-2">
         {data.incomingData !== undefined ? (
           <pre className="whitespace-pre-wrap break-all">{renderValue(data.incomingData)}</pre>
         ) : (
           <span className="italic opacity-70">Ожидание данных...</span>
         )}
       </div>
+      {data.response !== undefined && (
+        <div className="text-xs p-2 bg-indigo-700/50 rounded-sm mb-2 max-h-[150px] overflow-y-auto">
+          <pre className="whitespace-pre-wrap break-all">{renderValue(data.response)}</pre>
+        </div>
+      )}
+      {data.error && (
+        <div className="text-xs text-red-300 break-all mb-1">Ошибка: {data.error}</div>
+      )}
       <Handle type="source" position={Position.Right} className="!bg-slate-700 !w-3 !h-3" />
     </div>
   );


### PR DESCRIPTION
## Summary
- implement /api/llm endpoint for OpenAI requests
- extend LLMNode to show responses and errors
- create default config for LLM nodes when dropping
- make node processing async and support llmNode
- minor cleanup to satisfy lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842d795f9b88322a43499a6deec6ac2