### PR TITLE
Add Ollama node with local API

### DIFF
--- a/src/app/api/ollama/route.ts
+++ b/src/app/api/ollama/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { prompt, config = {} } = await req.json();
+    const {
+      base_url = "http://localhost:11434",
+      model_name = "llama2",
+      temperature = 0.7,
+      format,
+      metadata,
+      tags,
+      stop_tokens,
+      system,
+      template,
+      ...rest
+    } = config;
+
+    const options: Record<string, unknown> = {
+      temperature,
+      format,
+      metadata,
+      system,
+      template,
+      ...rest,
+    };
+    if (tags) options.tags = tags;
+    if (stop_tokens) options.stop = stop_tokens;
+    for (const key of Object.keys(options)) {
+      if (options[key] === undefined || options[key] === null)
+        delete options[key];
+    }
+
+    const body = {
+      model: model_name,
+      prompt: typeof prompt === "string" ? prompt : JSON.stringify(prompt),
+      stream: false,
+      options,
+    };
+
+    const apiUrl = `${base_url.replace(/\/$/, "")}/api/generate`;
+    const response = await fetch(apiUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    const text = await response.text();
+    interface OllamaResponse {
+      response?: unknown;
+      error?: unknown;
+      message?: { content?: unknown };
+      [key: string]: unknown;
+    }
+    let data: OllamaResponse;
+    try {
+      data = JSON.parse(text.split("\n").filter(Boolean).pop() || text);
+    } catch {
+      data = { response: text };
+    }
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: data.error || "Ollama error", raw_output: data },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json({
+      response: data.response ?? data.message?.content ?? data,
+      raw_output: data,
+    });
+  } catch (e) {
+    console.error("Ollama API error:", e);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -103,6 +103,7 @@ const categories: Category[] = [
     title: 'AI / ML',
     nodes: [
       { type: 'llmNode', label: 'LLM Node', description: 'Запрос к LLM' },
+      { type: 'ollamaNode', label: 'Ollama Node', description: 'Локальная LLM Ollama' },
       { type: 'embeddingNode', label: 'Embedding Node', description: 'Текст в вектор' },
       { type: 'vectorSearchNode', label: 'Vector Search Node', description: 'Поиск векторов' },
       { type: 'langChainAgentNode', label: 'LangChain Agent Node', description: 'Запуск агента' },

--- a/src/components/Nodes/OllamaNode.tsx
+++ b/src/components/Nodes/OllamaNode.tsx
@@ -1,0 +1,66 @@
+// src/components/Nodes/OllamaNode.tsx
+"use client";
+
+import React from "react";
+import { Handle, Position, NodeProps } from "@xyflow/react";
+
+const OllamaNode = ({
+  data,
+}: NodeProps<{
+  label?: string;
+  incomingData?: unknown;
+  response?: unknown;
+  error?: string;
+}>) => {
+  const renderValue = (value: unknown) => {
+    if (value === null) return "null";
+    if (value === undefined) return "undefined";
+    if (typeof value === "object") {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        return "[object]";
+      }
+    }
+    return String(value);
+  };
+
+  return (
+    <div className="px-4 py-3 shadow-md rounded-md bg-amber-600 border-2 border-amber-700 text-white w-60">
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!bg-slate-700 !w-3 !h-3"
+      />
+      <div className="text-sm font-bold mb-2">{data.label || "Ollama"}</div>
+      <div className="text-xs p-2 bg-amber-700/70 rounded-sm min-h-[40px] max-h-[150px] overflow-y-auto mb-2">
+        {data.incomingData !== undefined ? (
+          <pre className="whitespace-pre-wrap break-all">
+            {renderValue(data.incomingData)}
+          </pre>
+        ) : (
+          <span className="italic opacity-70">Ожидание данных...</span>
+        )}
+      </div>
+      {data.response !== undefined && (
+        <div className="text-xs p-2 bg-amber-700/50 rounded-sm mb-2 max-h-[150px] overflow-y-auto">
+          <pre className="whitespace-pre-wrap break-all">
+            {renderValue(data.response)}
+          </pre>
+        </div>
+      )}
+      {data.error && (
+        <div className="text-xs text-red-300 break-all mb-1">
+          Ошибка: {data.error}
+        </div>
+      )}
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!bg-slate-700 !w-3 !h-3"
+      />
+    </div>
+  );
+};
+
+export default OllamaNode;


### PR DESCRIPTION
## Summary
- add OllamaNode component
- register Ollama node type and palette entry
- call new `/api/ollama` endpoint from flow logic
- implement Ollama API route

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842dce3b7988322816642a96a99583a